### PR TITLE
Migrate to TanStack Router

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ To further improve the SignForge application, we plan to make the following opti
 
 ## Running Tests
 
+The project now uses [TanStack Router](https://tanstack.com/router) for client-side routing.
+
 Unit tests are written with [Vitest](https://vitest.dev/). After installing
 dependencies, run:
 

--- a/components/AUTH/PersistLogin.jsx
+++ b/components/AUTH/PersistLogin.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import usePersist from "../../hooks/usePersist";
-import { Outlet, useNavigate, Link } from "react-router-dom";
+import { Outlet, useNavigate, Link } from "@tanstack/react-router";
 import axiosInstance from "../../app/api/axiosInstance";
 import { useAuth } from "../../app/context/AuthContext";
 
@@ -33,7 +33,7 @@ const PersistLogin = () => {
       } catch (err) {
         setIsError(true);
         setError(err);
-        navigate("/");
+        navigate({ to: "/" });
       } finally {
         setIsLoading(false);
       }

--- a/components/AUTH/Prefetch.jsx
+++ b/components/AUTH/Prefetch.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from '@tanstack/react-router';
 import useAuth from '../../hooks/useAuth';
 import { useQueryClient } from '@tanstack/react-query';
 import { fetchImages } from '../../app/features/images/imagesApi';

--- a/components/DashboardLayout.jsx
+++ b/components/DashboardLayout.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { AppHeader } from './AppHeader';
 import { MantineProvider, AppShell } from '@mantine/core';
 import { SideBar } from './Sidebar';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from '@tanstack/react-router';
 function DashboardLayout() {
   const [opened, setOpened] = useState(false);
 

--- a/components/Images/ImageDrop.jsx
+++ b/components/Images/ImageDrop.jsx
@@ -11,7 +11,7 @@ import {
 import { Dropzone, MIME_TYPES } from '@mantine/dropzone';
 import { IconCloudUpload, IconX, IconDownload } from '@tabler/icons-react';
 import { useAddImage } from '../../app/features/images/imagesApi';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 const useStyles = createStyles((theme) => ({
@@ -71,7 +71,7 @@ function ImageDropZone(props) {
     try {
       await addImageMutation.mutateAsync(await uploadImage(file));
       props.handle();
-      navigate('./');
+      navigate({ to: './' });
       props.handleLoading.close();
     } catch (err) {
       console.error("couldn't upload file!", err);

--- a/components/LoginPage.jsx
+++ b/components/LoginPage.jsx
@@ -129,7 +129,7 @@ function LoginPage() {
             </Title>
             <Text color="dimmed" size="sm" align="center" mt={5}>
               Do not have an account yet?{' '}
-              <Link to="../home/signuppage">Create account</Link>
+              <Link to="../home/signuppage" preload="intent">Create account</Link>
             </Text>
           </Flex>
 

--- a/components/LoginPage.jsx
+++ b/components/LoginPage.jsx
@@ -13,7 +13,7 @@ import {
   Flex,
 } from '@mantine/core';
 import bg from '../src/assets/bg-image/office-bg.jpg';
-import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { Link, Navigate, useNavigate } from '@tanstack/react-router';
 import { useState, useRef, useEffect } from 'react';
 
 

--- a/components/LoginPage2.jsx
+++ b/components/LoginPage2.jsx
@@ -13,7 +13,7 @@ import {
   Flex,
 } from '@mantine/core';
 import bg from '../src/assets/bg-image/office-bg.jpg';
-import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { Link, Navigate, useNavigate } from '@tanstack/react-router';
 import { useState, useRef, useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import axiosInstance from "../app/api/axiosInstance";
@@ -98,7 +98,7 @@ function LoginPage() {
       setAuth({ token: accessToken, user });
       setEmail('');
       setPassword('');
-      navigate('/dashboard');
+      navigate({ to: '/dashboard' });
     } catch (err) {
       console.error('Error in handleSubmit:', err);
       if (!err.status) {

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -11,7 +11,7 @@ import {
     IconMovie
   } from '@tabler/icons-react';
 
-import { Link, useLocation, useNavigate} from 'react-router-dom';
+import { Link, useLocation, useNavigate } from '@tanstack/react-router';
 import {useMediaQuery } from '@mantine/hooks'
 
 

--- a/components/Sidebar.jsx
+++ b/components/Sidebar.jsx
@@ -124,6 +124,7 @@ const [active, setActive] = useState(() => {
       key={item.label}
       variant="link"
       component={Link}
+      preload="intent"
       onClick={() => handleClick(item.label, opened, isMobile)}
     >
       <item.icon className={classes.linkIcon} stroke={1.5} />

--- a/components/SignUpPage.jsx
+++ b/components/SignUpPage.jsx
@@ -17,7 +17,7 @@ import {
 } from '@mantine/core';
 import bg from '../src/assets/bg-image/office-bg.jpg';
 import { IconArrowLeft } from '@tabler/icons-react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useAddUser } from "../app/features/users/usersApi";
 
 const useStyles = createStyles((theme) => ({
@@ -70,7 +70,7 @@ function SignUpPage() {
   function handleNewUserSubmit(data) {
     try {
       addNewUser({ ...data });
-      navigate('../login');
+      navigate({ to: '../login' });
     } catch {
       console.error(error);
     }

--- a/components/SignUpPage.jsx
+++ b/components/SignUpPage.jsx
@@ -137,7 +137,7 @@ function SignUpPage() {
 
             <Group position="apart">
               <Text color="dimmed" size="sm" className={classes.control}>
-                <Link to="../login">
+                <Link to="../login" preload="intent">
                   <Center inline mt={14} className={classes.control}>
                     <IconArrowLeft size={rem(12)} stroke={1.5} />
                     <Box ml={5}>Back to the login page</Box>

--- a/components/error.jsx
+++ b/components/error.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useRouteError } from 'react-router-dom';
+import { useRouteError } from '@tanstack/react-router';
 
 function Error() {
   const error = useRouteError();

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,14 +19,15 @@
         "@mantine/modals": "^6.0.2",
         "@tabler/icons-react": "^2.10.0",
         "@tanstack/react-query": "^5.74.11",
+        "@tanstack/react-router": "^1.120.15",
+        "@tanstack/react-router-devtools": "^1.120.15",
         "axios": "^1.9.0",
         "dayjs": "^1.11.7",
         "iframe-resizer-react": "^1.1.0",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^6.9.0"
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@tanstack/react-query-devtools": "^5.74.11",
@@ -1521,15 +1522,6 @@
         "react": "^16.8 || ^17.0 || ^18.0"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.41.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
@@ -1837,6 +1829,19 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@tanstack/history": {
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.115.0.tgz",
+      "integrity": "sha512-K7JJNrRVvyjAVnbXOH2XLRhFXDkeP54Kt2P4FR1Kl2KDGlIbkua5VqZQD2rot3qaDrpufyUa63nuLai1kOLTsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.74.9",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.9.tgz",
@@ -1890,6 +1895,136 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.74.11",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-router": {
+      "version": "1.120.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.120.15.tgz",
+      "integrity": "sha512-apzBmXh4pHwqUGU3kD8y2FJMi7rVoUbRxh5oV7v8kEb6Aq5Xpdo+OcpThw8h/M2zv7v4Ef8IoY6WFCKKu3HBjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.115.0",
+        "@tanstack/react-store": "^0.7.0",
+        "@tanstack/router-core": "1.120.15",
+        "jsesc": "^3.1.0",
+        "tiny-invariant": "^1.3.3",
+        "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-router-devtools": {
+      "version": "1.120.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.120.15.tgz",
+      "integrity": "sha512-5KcUXc3fkiLo/6Y56gOM3JqmYXG1ElIH2iyUWuG5IlcegLrpXhu4OBQ+8Q4+62CD0OKy0ifUDyemrCOAEOfCvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/router-devtools-core": "^1.120.15",
+        "solid-js": "^1.9.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-router": "^1.120.15",
+        "react": ">=18.0.0 || >=19.0.0",
+        "react-dom": ">=18.0.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.1.tgz",
+      "integrity": "sha512-qUTEKdId6QPWGiWyKAPf/gkN29scEsz6EUSJ0C3HgLMgaqTAyBsQ2sMCfGVcqb+kkhEXAdjleCgH6LAPD6f2sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.7.1",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/router-core": {
+      "version": "1.120.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.120.15.tgz",
+      "integrity": "sha512-soLj+mEuvSxAVFK/3b85IowkkvmSuQL6J0RSIyKJFGFgy0CmUzpcBGEO99+JNWvvvzHgIoY4F4KtLIN+rvFSFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/history": "1.115.0",
+        "@tanstack/store": "^0.7.0",
+        "tiny-invariant": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/router-devtools-core": {
+      "version": "1.120.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.120.15.tgz",
+      "integrity": "sha512-AT9obPHKpJqnHMbwshozSy6sApg5LchiAll3blpS3MMDybUCidYHrdhe9MZJLmlC99IQiEGmuZERP3VRcuPNHg==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/router-core": "^1.120.15",
+        "csstype": "^3.0.10",
+        "solid-js": ">=1.9.5",
+        "tiny-invariant": "^1.3.3"
+      },
+      "peerDependenciesMeta": {
+        "csstype": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/router-devtools-core/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.1.tgz",
+      "integrity": "sha512-PjUQKXEXhLYj2X5/6c1Xn/0/qKY0IVFxTJweopRfF26xfjVyb14yALydJrHupDh3/d+1WKmfEgZPBVCmDkzzwg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -2902,6 +3037,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3717,38 +3861,6 @@
         }
       }
     },
-    "node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
-      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -3888,12 +4000,44 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/seroval": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
+      "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.3.2.tgz",
+      "integrity": "sha512-0QvCV2lM3aj/U3YozDiVwx9zpH0q8A60CTWIv4Jszj/givcudPb48B+rkU5D51NJ0pTpweGMttHjboPa9/zoIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.7.tgz",
+      "integrity": "sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.3.0",
+        "seroval-plugins": "~1.3.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -3977,6 +4121,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -4217,6 +4367,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     "@mantine/modals": "^6.0.2",
     "@tabler/icons-react": "^2.10.0",
     "@tanstack/react-query": "^5.74.11",
+    "@tanstack/react-router": "^1.120.15",
+    "@tanstack/react-router-devtools": "^1.120.15",
     "axios": "^1.9.0",
     "dayjs": "^1.11.7",
     "iframe-resizer-react": "^1.1.0",
     "jwt-decode": "^3.1.2",
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
-    "react-dom": "^18.2.0",
-    "react-router-dom": "^6.9.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.74.11",

--- a/src/HomePage.jsx
+++ b/src/HomePage.jsx
@@ -13,7 +13,7 @@ import { useDisclosure } from '@mantine/hooks';
 import { IconChevronDown } from '@tabler/icons-react';
 import { MantineLogo } from '@mantine/ds';
 import { DsLogo } from '../components/misc/Dslogo';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from '@tanstack/react-router';
 
 const HEADER_HEIGHT = rem(60);
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,20 +9,7 @@ import { AuthProvider } from '../app/context/AuthContext';
 
 
 
-import ImagePage from '../components/Images/ImagePage';
-import { DemoPage } from '../components/DemoPage';
-import { PlayersPage } from '../components/players/PlayersPage';
-import { DashboardLayout } from '../components/DashboardLayout';
-import { LoginPage } from '../components/LoginPage2';
-import { ComingSoon } from '../components/ComingSoon';
-import { NotFoundPage } from '../components/NotFoundPage';
-import { SignUpPage } from '../components/SignUpPage';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { HomePage } from './HomePage';
-import { MessagesPage } from '../components/messages/MessagePage';
-import { Prefetch } from '../components/AUTH/Prefetch';
-import PersistLogin from '../components/AUTH/PersistLogin';
-import { Welcome } from '../components/Welcome';
+import { AppRouter } from './router';
 import { disableReactDevTools } from '@fvilers/disable-react-devtools';
 
 if(process.env.NODE_ENV === 'production') disableReactDevTools()
@@ -32,28 +19,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
 
     <AuthProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<App />} />
-          <Route path="/home" element={<HomePage />}>
-            <Route path="/home/login" element={<LoginPage />} />
-            <Route path="/home/signuppage" element={<SignUpPage />} />
-          </Route>
-          <Route element={<PersistLogin />}>
-            <Route element={<Prefetch />}>
-              <Route path="/dashboard" element={<DashboardLayout />}>
-                <Route path="/dashboard/" element={<Welcome />} />
-                <Route path="/dashboard/players" element={<PlayersPage />} />
-                <Route path="/dashboard/playlist" element={<ComingSoon />} />
-                <Route path="/dashboard/messages" element={<MessagesPage />} />
-                <Route path="/dashboard/assets" element={<ImagePage />} />
-                <Route path="/dashboard/demo" element={<DemoPage />} />
-              </Route>
-            </Route>
-          </Route>
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
-      </BrowserRouter>
+      <AppRouter />
     </AuthProvider>
   </QueryClientProvider>
 );

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import {
+  RouterProvider,
+  createRouter,
+  createRootRoute,
+  createRoute,
+  Outlet,
+} from '@tanstack/react-router';
+
+import { App } from './App';
+import { HomePage } from './HomePage';
+import { LoginPage } from '../components/LoginPage2';
+import { SignUpPage } from '../components/SignUpPage';
+import { DashboardLayout } from '../components/DashboardLayout';
+import { PlayersPage } from '../components/players/PlayersPage';
+import { MessagesPage } from '../components/messages/MessagePage';
+import ImagePage from '../components/Images/ImagePage';
+import { DemoPage } from '../components/DemoPage';
+import { ComingSoon } from '../components/ComingSoon';
+import { Welcome } from '../components/Welcome';
+import { Prefetch } from '../components/AUTH/Prefetch';
+import PersistLogin from '../components/AUTH/PersistLogin';
+import { NotFoundPage } from '../components/NotFoundPage';
+
+const rootRoute = createRootRoute({
+  component: () => <Outlet />,
+});
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: App,
+});
+
+const homeRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'home',
+  component: HomePage,
+});
+
+const loginRoute = createRoute({
+  getParentRoute: () => homeRoute,
+  path: 'login',
+  component: LoginPage,
+});
+
+const signUpRoute = createRoute({
+  getParentRoute: () => homeRoute,
+  path: 'signuppage',
+  component: SignUpPage,
+});
+
+const persistRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: 'persist',
+  component: PersistLogin,
+});
+
+const prefetchRoute = createRoute({
+  getParentRoute: () => persistRoute,
+  id: 'prefetch',
+  component: Prefetch,
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => prefetchRoute,
+  path: 'dashboard',
+  component: DashboardLayout,
+});
+
+const welcomeRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: '/',
+  component: Welcome,
+});
+
+const playersRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: 'players',
+  component: PlayersPage,
+});
+
+const playlistRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: 'playlist',
+  component: ComingSoon,
+});
+
+const messagesRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: 'messages',
+  component: MessagesPage,
+});
+
+const assetsRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: 'assets',
+  component: ImagePage,
+});
+
+const demoRoute = createRoute({
+  getParentRoute: () => dashboardRoute,
+  path: 'demo',
+  component: DemoPage,
+});
+
+const notFoundRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '*',
+  component: NotFoundPage,
+});
+
+rootRoute.addChildren([
+  indexRoute,
+  homeRoute.addChildren([loginRoute, signUpRoute]),
+  persistRoute.addChildren([
+    prefetchRoute.addChildren([
+      dashboardRoute.addChildren([
+        welcomeRoute,
+        playersRoute,
+        playlistRoute,
+        messagesRoute,
+        assetsRoute,
+        demoRoute,
+      ]),
+    ]),
+  ]),
+  notFoundRoute,
+]);
+
+const router = createRouter({ routeTree: rootRoute });
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -6,6 +6,10 @@ import {
   createRoute,
   Outlet,
 } from '@tanstack/react-router';
+import queryClient from '../app/queryClient';
+import { fetchImages } from '../app/features/images/imagesApi';
+import { fetchPlayers } from '../app/features/players/playersApi';
+import { fetchMessages } from '../app/features/message/messagesApi';
 
 import { App } from './App';
 import { HomePage } from './HomePage';
@@ -78,6 +82,11 @@ const playersRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: 'players',
   component: PlayersPage,
+  loader: () =>
+    queryClient.ensureQueryData({
+      queryKey: ['players'],
+      queryFn: fetchPlayers,
+    }),
 });
 
 const playlistRoute = createRoute({
@@ -90,12 +99,22 @@ const messagesRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: 'messages',
   component: MessagesPage,
+  loader: () =>
+    queryClient.ensureQueryData({
+      queryKey: ['messages'],
+      queryFn: fetchMessages,
+    }),
 });
 
 const assetsRoute = createRoute({
   getParentRoute: () => dashboardRoute,
   path: 'assets',
   component: ImagePage,
+  loader: () =>
+    queryClient.ensureQueryData({
+      queryKey: ['images'],
+      queryFn: fetchImages,
+    }),
 });
 
 const demoRoute = createRoute({
@@ -128,7 +147,11 @@ rootRoute.addChildren([
   notFoundRoute,
 ]);
 
-const router = createRouter({ routeTree: rootRoute });
+const router = createRouter({
+  routeTree: rootRoute,
+  defaultPreload: 'intent',
+  defaultPreloadStaleTime: 0,
+});
 
 export function AppRouter() {
   return <RouterProvider router={router} />;


### PR DESCRIPTION
## Summary
- install `@tanstack/react-router`
- create `AppRouter` with route tree
- replace React Router usage with TanStack Router
- document new router in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840d721d29483288f1e90a75de3b7bf